### PR TITLE
fix(app): move to cookie mode

### DIFF
--- a/modules/directus/runtime/plugins/directus.ts
+++ b/modules/directus/runtime/plugins/directus.ts
@@ -9,7 +9,7 @@ export default defineNuxtPlugin((nuxtApp) => {
 	const directusURL = config.public.directus.rest.baseUrl as string;
 
 	const directus = createDirectus<Schema>(directusURL, { globals: { fetch: $fetch } })
-		.with(authentication('session', { credentials: 'include' }))
+		.with(authentication('cookie', { credentials: 'include' }))
 		.with(rest({ credentials: 'include' }));
 
 	// ** Live Preview Bits **


### PR DESCRIPTION
## Scope

What's changed:

- Updates the directus client side plugin to use `cookie` mode for requests. 
  - `session` mode does not play friendly with cross-domain frontends which should be supported

## Potential Risks / Drawbacks

- N/A

## Review Notes / Questions

- N/A

---

Follow up: #98 
