### PR TITLE
fix: point root to intended CMS page

### DIFF
--- a/pages/[...permalink].vue
+++ b/pages/[...permalink].vue
@@ -11,7 +11,7 @@ const pageFilter = computed(() => {
 
 	if (path === '/') {
 		// Match the homepage
-		finalPath = '/';
+		finalPath = '/home';
 	} else if (path.endsWith('/')) {
 		// Remove any other trailing slash
 		finalPath = path.slice(0, -1);


### PR DESCRIPTION
This PR fixes the issue where the root path was pointing to an non-existent CMS page. 
Causing the site to return a 404, which leads the user to believe the whole site or CMS is down.

_<sup>both using https://v2-agencyos.directus.app</sub>_
![image](https://github.com/user-attachments/assets/952f5898-463b-45fd-8473-494889d91409)